### PR TITLE
Define without dependencies should execute callback

### DIFF
--- a/amdrequire.js
+++ b/amdrequire.js
@@ -114,6 +114,10 @@ var Module = require('module'),
 			//Require all the dependencies
 			exp = amdrequire(deps, callback, defineModuleStack[defineModuleStack.length - 1]);
 		}
+		// No dependencies, first arg as callback
+		else if(!callback && typeof deps === 'function'){
+			exp = deps();
+		}
 		// Define a module directly as an object
 		else if(deps !== null && typeof deps === 'object'){
 			exp = deps;


### PR DESCRIPTION
Hi

According to requireJS api - user can define a module without specifying any dependencies, he can omit first  argument and pass callback directly
http://requirejs.org/docs/api.html#define

So i added this to define - if there's no callback and first parameter is a function - execute it   
